### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
 FROM alpine:3.6
 
-RUN \
-    apk update && \
-    apk add --no-cache --no-progress mysql-client
+RUN apk add --no-cache --no-progress mysql-client


### PR DESCRIPTION
No need to `apk update` when using `--no-cache` option.